### PR TITLE
Fix user count not showing when users join a room

### DIFF
--- a/socket-server/index.js
+++ b/socket-server/index.js
@@ -33,8 +33,10 @@ io.on("connection", (socket) => {
     // Add user to room
     roomUsers[roomId].add(socket.id);
     
-    // Emit to others that user joined
-    socket.to(roomId).emit("user-joined", socket.id);
+    // Emit to everyone in the room that user joined
+    io.in(roomId).emit("user-joined", {
+      userId: socket.id
+    });
     
     // Emit current user count to everyone in the room
     io.to(roomId).emit("user-count", roomUsers[roomId].size);

--- a/src/components/RoomPageClient.tsx
+++ b/src/components/RoomPageClient.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import CodeEditor from '@/components/CodeEditor';
 import { Header } from '@/components/Header';
 import { useSocket } from '@/hooks/useSocket';
+import { useRoomUserCount } from '@/hooks/useRoomUserCount';
 
 interface RoomPageClientProps {
   roomId: string;
@@ -11,6 +12,7 @@ interface RoomPageClientProps {
 
 const RoomPageClient = ({ roomId }: RoomPageClientProps) => {
   const socket = useSocket();
+  const { userCount } = useRoomUserCount();
 
   useEffect(() => {
     if (!socket) return;
@@ -34,7 +36,7 @@ const RoomPageClient = ({ roomId }: RoomPageClientProps) => {
 
   return (
     <div className="flex flex-col h-screen">
-      <Header roomId={roomId} userCount={0} />
+      <Header roomId={roomId} userCount={userCount} />
 
       <div className="flex-1 overflow-hidden">
         <CodeEditor roomId={roomId} />

--- a/src/components/RoomPageClient.tsx
+++ b/src/components/RoomPageClient.tsx
@@ -5,6 +5,7 @@ import CodeEditor from '@/components/CodeEditor';
 import { Header } from '@/components/Header';
 import { useSocket } from '@/hooks/useSocket';
 import { useRoomUserCount } from '@/hooks/useRoomUserCount';
+import { toast } from 'sonner';
 
 interface RoomPageClientProps {
   roomId: string;
@@ -23,6 +24,10 @@ const RoomPageClient = ({ roomId }: RoomPageClientProps) => {
     }
 
     socket.emit('join-room', roomId);
+
+    socket.on('user-joined', () => {
+      toast.success(`A new user has joined your room ${roomId}`);
+    });
 
     return () => {
       // We don't disconnect here, as the socket is managed by the context

--- a/src/components/RoomPageClient.tsx
+++ b/src/components/RoomPageClient.tsx
@@ -24,6 +24,7 @@ const RoomPageClient = ({ roomId }: RoomPageClientProps) => {
     }
 
     socket.emit('join-room', roomId);
+    toast.success(`You joined room ${roomId}`);
 
     socket.on('user-joined', () => {
       toast.success(`A new user has joined your room ${roomId}`);

--- a/src/hooks/useRoomUserCount.ts
+++ b/src/hooks/useRoomUserCount.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { useSocket } from './useSocket';
+
+
+export function useRoomUserCount() {
+   const [userCount, setUserCount] = useState(0);
+   const socket = useSocket();
+
+   useEffect(() => {
+      if (!socket) return;
+
+      // Listen for direct user count updates
+      socket.on('user-count', (count: number) => {
+         setUserCount(count);
+      });
+
+      return () => {
+         socket.off('user-count');
+      };
+   }, [socket]);
+
+   return { userCount };
+}


### PR DESCRIPTION
## 📌 Description

This PR fixes the room user count not showing when users join a room 
- Added the `useRoomUserCount` hook that returns the numbers of users in a room 
- Added a toast message for when a user joins a room 

Fixes #38 

---

## ✅ Type of Change

> Please delete options that are not relevant.

- [x] Bug fix 🐛

---

## 📸 Screenshots (if applicable)

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/17a5d1b9-8bbe-40b5-a0f6-9511a302b5c9" width="300"/> | <img src="https://github.com/user-attachments/assets/ec4e37e7-56a5-4458-8c38-c38e9dc26938" width="300"/> |

---


## 🚨 Checklist

- [x] I have tested my code locally
- [ ] I have added necessary tests where applicable
- [x] I have added comments/documentation where necessary
- [ ] I have updated the README (if required)
- [x] My changes follow the project’s code style and conventions

---

## 📝 Additional Info

> Add any other relevant context or links here.
